### PR TITLE
feat!: simple stupid pruning

### DIFF
--- a/test/util/common.go
+++ b/test/util/common.go
@@ -321,7 +321,7 @@ func CreateTestEnvWithoutAttestationNonceInit(t *testing.T) TestInput {
 func CreateTestEnv(t *testing.T) TestInput {
 	input := CreateTestEnvWithoutAttestationNonceInit(t)
 	input.QgbKeeper.SetLatestAttestationNonce(input.Context, 0)
-	input.QgbKeeper.SetLastAvailableAttestationNonce(input.Context, 1)
+	input.QgbKeeper.SetOldestAttestationNonce(input.Context, 1)
 	input.QgbKeeper.SetLastUnbondingNonce(input.Context, 0)
 	return input
 }

--- a/test/util/common.go
+++ b/test/util/common.go
@@ -322,7 +322,7 @@ func CreateTestEnv(t *testing.T) TestInput {
 	input := CreateTestEnvWithoutAttestationNonceInit(t)
 	input.QgbKeeper.SetLatestAttestationNonce(input.Context, 0)
 	input.QgbKeeper.SetOldestAttestationNonce(input.Context, 1)
-	input.QgbKeeper.SetLastUnbondingNonce(input.Context, 0)
+	input.QgbKeeper.SetValsetUpdateHeight(input.Context, 1)
 	return input
 }
 

--- a/x/qgb/genesis.go
+++ b/x/qgb/genesis.go
@@ -15,7 +15,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	// Also, it's easier to set it here to 1 instead of doing it in abci.EndBlocker and do
 	// the check on every iteration
 	k.SetOldestAttestationNonce(ctx, 1)
-	k.SetLastUnbondingNonce(ctx, 0)
+	k.SetValsetUpdateHeight(ctx, 1)
 	k.SetParams(ctx, *genState.Params)
 }
 

--- a/x/qgb/genesis.go
+++ b/x/qgb/genesis.go
@@ -14,7 +14,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	// a new valset will be created all the time.
 	// Also, it's easier to set it here to 1 instead of doing it in abci.EndBlocker and do
 	// the check on every iteration
-	k.SetLastAvailableAttestationNonce(ctx, 1)
+	k.SetOldestAttestationNonce(ctx, 1)
 	k.SetLastUnbondingNonce(ctx, 0)
 	k.SetParams(ctx, *genState.Params)
 }

--- a/x/qgb/keeper/hooks.go
+++ b/x/qgb/keeper/hooks.go
@@ -30,7 +30,6 @@ func (h Hooks) AfterValidatorBeginUnbonding(ctx sdk.Context, _ sdk.ConsAddress, 
 	// in the endblocker therefore we call the keeper function ourselves there.
 
 	h.k.SetLastUnBondingBlockHeight(ctx, uint64(ctx.BlockHeight()))
-	h.k.SetLastUnbondingNonce(ctx, h.k.GetLatestAttestationNonce(ctx))
 	return nil
 }
 

--- a/x/qgb/keeper/keeper_attestation.go
+++ b/x/qgb/keeper/keeper_attestation.go
@@ -86,13 +86,13 @@ func (k Keeper) CheckLastAvailableAttestationNonce(ctx sdk.Context) bool {
 	return has
 }
 
-// GetLastAvailableAttestationNonce returns the last available attestation nonce. The
+// GetOldestAttestationNonce returns the last available attestation nonce. The
 // nonce is of the last available attestation in store that can be
 // retrieved. Panics if the last available attestation
 // nonce doesn't exit. This value is set on chain startup. However, it won't be
 // written to store until height = 1. Thus, it's mandatory to run
 // `CheckLastAvailableAttestationNonce` before calling this method.
-func (k Keeper) GetLastAvailableAttestationNonce(ctx sdk.Context) uint64 {
+func (k Keeper) GetOldestAttestationNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
 	bytes := store.Get([]byte(types.LastAvailableAttestationNonce))
 	if bytes == nil {
@@ -101,9 +101,9 @@ func (k Keeper) GetLastAvailableAttestationNonce(ctx sdk.Context) uint64 {
 	return UInt64FromBytes(bytes)
 }
 
-// SetLastAvailableAttestationNonce sets the last available attestation nonce.
+// SetOldestAttestationNonce sets the last available attestation nonce.
 // The nonce is of the last available attestation in store that can be retrieved.
-func (k Keeper) SetLastAvailableAttestationNonce(ctx sdk.Context, nonce uint64) {
+func (k Keeper) SetOldestAttestationNonce(ctx sdk.Context, nonce uint64) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set([]byte(types.LastAvailableAttestationNonce), types.UInt64Bytes(nonce))
 }

--- a/x/qgb/keeper/keeper_attestation.go
+++ b/x/qgb/keeper/keeper_attestation.go
@@ -78,62 +78,34 @@ func (k Keeper) GetLatestAttestationNonce(ctx sdk.Context) uint64 {
 	return UInt64FromBytes(bytes)
 }
 
-// CheckLastAvailableAttestationNonce returns true if the last available attestation nonce has been initialized
+// CheckOldestAttestationNonce returns true if the last available attestation nonce has been initialized
 // in store, and false if not.
-func (k Keeper) CheckLastAvailableAttestationNonce(ctx sdk.Context) bool {
+func (k Keeper) CheckOldestAttestationNonce(ctx sdk.Context) bool {
 	store := ctx.KVStore(k.storeKey)
 	has := store.Has([]byte(types.LatestAttestationtNonce))
 	return has
 }
 
 // GetOldestAttestationNonce returns the last available attestation nonce. The
-// nonce is of the last available attestation in store that can be
-// retrieved. Panics if the last available attestation
-// nonce doesn't exit. This value is set on chain startup. However, it won't be
-// written to store until height = 1. Thus, it's mandatory to run
-// `CheckLastAvailableAttestationNonce` before calling this method.
+// nonce is of the last available attestation in store that can be retrieved.
+// Panics if the last available attestation nonce doesn't exit. This value is
+// set on chain startup. However, it won't be written to store until height = 1.
+// Thus, it's mandatory to run `CheckOldestAttestationNonce` before
+// calling this method.
 func (k Keeper) GetOldestAttestationNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	bytes := store.Get([]byte(types.LastAvailableAttestationNonce))
+	bytes := store.Get([]byte(types.OldestAttestationNonce))
 	if bytes == nil {
 		panic("nil last available attestation nonce")
 	}
 	return UInt64FromBytes(bytes)
 }
 
-// SetOldestAttestationNonce sets the last available attestation nonce.
-// The nonce is of the last available attestation in store that can be retrieved.
+// SetOldestAttestationNonce sets the last available attestation nonce. The
+// nonce is of the last available attestation in store that can be retrieved.
 func (k Keeper) SetOldestAttestationNonce(ctx sdk.Context, nonce uint64) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set([]byte(types.LastAvailableAttestationNonce), types.UInt64Bytes(nonce))
-}
-
-// CheckLastUnbondingNonce returns true if the last unbonding nonce has been initialized
-// in store, and false if not.
-func (k Keeper) CheckLastUnbondingNonce(ctx sdk.Context) bool {
-	store := ctx.KVStore(k.storeKey)
-	has := store.Has([]byte(types.LastUnbondingNonce))
-	return has
-}
-
-// GetLastUnbondingNonce returns the last unbonding nonce.
-// Panics if the last unbonding nonce doesn't exit. Make sure to call `CheckLastUnbondingNonce`
-// before getting the nonce.
-// This value is set on chain startup. However, it won't be written to store until height = 1.
-// Thus, it's mandatory to run `CheckLastUnbondingNonce` before calling this method.
-func (k Keeper) GetLastUnbondingNonce(ctx sdk.Context) uint64 {
-	store := ctx.KVStore(k.storeKey)
-	bytes := store.Get([]byte(types.LastUnbondingNonce))
-	if bytes == nil {
-		panic("nil last unbonding nonce")
-	}
-	return UInt64FromBytes(bytes)
-}
-
-// SetLastUnbondingNonce sets the attestation nonce corresponding the last unbonding height.
-func (k Keeper) SetLastUnbondingNonce(ctx sdk.Context, nonce uint64) {
-	store := ctx.KVStore(k.storeKey)
-	store.Set([]byte(types.LastUnbondingNonce), types.UInt64Bytes(nonce))
+	store.Set([]byte(types.OldestAttestationNonce), types.UInt64Bytes(nonce))
 }
 
 // GetAttestationByNonce returns an attestation request by nonce.

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -67,7 +67,7 @@ func (k Keeper) GetDataCommitmentForHeight(ctx sdk.Context, height uint64) (type
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return types.DataCommitment{}, types.ErrLatestAttestationNonceStillNotInitialized
 	}
-	if !k.CheckLastAvailableAttestationNonce(ctx) {
+	if !k.CheckOldestAttestationNonce(ctx) {
 		return types.DataCommitment{}, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	latestNonce := k.GetLatestAttestationNonce(ctx)
@@ -97,7 +97,7 @@ func (k Keeper) GetLastDataCommitment(ctx sdk.Context) (types.DataCommitment, er
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return types.DataCommitment{}, types.ErrLatestAttestationNonceStillNotInitialized
 	}
-	if !k.CheckLastAvailableAttestationNonce(ctx) {
+	if !k.CheckOldestAttestationNonce(ctx) {
 		return types.DataCommitment{}, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	latestNonce := k.GetLatestAttestationNonce(ctx)
@@ -124,7 +124,7 @@ func (k Keeper) HasDataCommitmentInStore(ctx sdk.Context) (bool, error) {
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return false, nil
 	}
-	if !k.CheckLastAvailableAttestationNonce(ctx) {
+	if !k.CheckOldestAttestationNonce(ctx) {
 		return false, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	latestNonce := k.GetLatestAttestationNonce(ctx)

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -71,7 +71,7 @@ func (k Keeper) GetDataCommitmentForHeight(ctx sdk.Context, height uint64) (type
 		return types.DataCommitment{}, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	latestNonce := k.GetLatestAttestationNonce(ctx)
-	lastAvailableNonce := k.GetLastAvailableAttestationNonce(ctx)
+	lastAvailableNonce := k.GetOldestAttestationNonce(ctx)
 	for i := latestNonce; i >= lastAvailableNonce; i-- {
 		// TODO better search
 		att, found, err := k.GetAttestationByNonce(ctx, i)
@@ -101,7 +101,7 @@ func (k Keeper) GetLastDataCommitment(ctx sdk.Context) (types.DataCommitment, er
 		return types.DataCommitment{}, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	latestNonce := k.GetLatestAttestationNonce(ctx)
-	lastAvailableNonce := k.GetLastAvailableAttestationNonce(ctx)
+	lastAvailableNonce := k.GetOldestAttestationNonce(ctx)
 	for i := latestNonce; i >= lastAvailableNonce; i-- {
 		att, found, err := k.GetAttestationByNonce(ctx, i)
 		if err != nil {
@@ -128,7 +128,7 @@ func (k Keeper) HasDataCommitmentInStore(ctx sdk.Context) (bool, error) {
 		return false, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	latestNonce := k.GetLatestAttestationNonce(ctx)
-	lastAvailableNonce := k.GetLastAvailableAttestationNonce(ctx)
+	lastAvailableNonce := k.GetOldestAttestationNonce(ctx)
 	for i := lastAvailableNonce; i <= latestNonce; i++ {
 		att, found, err := k.GetAttestationByNonce(ctx, i)
 		if err != nil {

--- a/x/qgb/keeper/keeper_valset.go
+++ b/x/qgb/keeper/keeper_valset.go
@@ -23,7 +23,7 @@ func (k Keeper) GetLatestValset(ctx sdk.Context) (*types.Valset, error) {
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return nil, types.ErrLatestAttestationNonceStillNotInitialized
 	}
-	if !k.CheckLastAvailableAttestationNonce(ctx) {
+	if !k.CheckOldestAttestationNonce(ctx) {
 		return nil, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	latestNonce := k.GetLatestAttestationNonce(ctx)
@@ -168,7 +168,7 @@ func (k Keeper) GetLastValsetBeforeNonce(ctx sdk.Context, nonce uint64) (*types.
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return nil, types.ErrLatestAttestationNonceStillNotInitialized
 	}
-	if !k.CheckLastAvailableAttestationNonce(ctx) {
+	if !k.CheckOldestAttestationNonce(ctx) {
 		return nil, types.ErrLastAvailableNonceStillNotInitialized
 	}
 	if nonce == 1 {

--- a/x/qgb/pruning.go
+++ b/x/qgb/pruning.go
@@ -1,0 +1,105 @@
+package qgb
+
+import (
+	"fmt"
+
+	"github.com/celestiaorg/celestia-app/x/qgb/keeper"
+	"github.com/celestiaorg/celestia-app/x/qgb/types"
+	v1 "github.com/celestiaorg/celestia-app/x/qgb/v1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// PruneIfNeeded runs basic checks on saved attestations to see if pruning is
+// required. Pruning occurs for attestations that were set from a height that
+// surpasses the PruningThreshold (220_000 blocks). This function will always
+// stop the state machine from pruning the oldest validator set.
+func PruneIfNeeded(ctx sdk.Context, k keeper.Keeper) {
+	// If the attestations nonce hasn't been initialized yet, no pruning is
+	// required
+	if !k.CheckLatestAttestationNonce(ctx) {
+		return
+	}
+
+	// always keep the oldest validator set update, which gets set at least
+	// every time a validator reaches the unbonding height. This covers the edge
+	// case where there are no validator set updates for the pruning period. In
+	// this case, we don't want to prune because we want the relayer to have a
+	// snapshot of the evm version of the validator set at that height.
+	oldestNonce := k.GetOldestAttestationNonce(ctx)
+	oldestNonceHeight := getOldestNonceHeight(ctx, k, oldestNonce)
+	newestValsetUpdate := k.GetValsetUpdateHeight(ctx)
+	if oldestNonceHeight == int64(newestValsetUpdate) {
+		return
+	}
+
+	// pruning is only needed if there are attestations that exceed the threshold
+	if int64(oldestNonceHeight) > ctx.BlockHeader().Height-PruningThreshold(ctx.BlockHeader().Version.App) {
+		return
+	}
+
+	// prune a single attestation per block. combined with the above check, this
+	// ensures that the last valset update is never deleted until there is at
+	// least one valset
+	pruneAttestation(ctx, k)
+}
+
+// getOldestNonceHeight returns the block height corresponding to the last available
+// nonce in store.
+func getOldestNonceHeight(ctx sdk.Context, k keeper.Keeper, nonce uint64) int64 {
+	lastAttestationInStore, found, err := k.GetAttestationByNonce(ctx, nonce)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		panic(fmt.Sprintf("couldn't find attestation %s for pruning", lastAttestationInStore))
+	}
+	switch lastAttestationInStore.Type() {
+	case types.DataCommitmentRequestType:
+		dc := lastAttestationInStore.(*types.DataCommitment)
+		return int64(dc.EndBlock)
+	case types.ValsetRequestType:
+		vs := lastAttestationInStore.(*types.Valset)
+		return int64(vs.Height)
+	default:
+		panic("unknown attestation type")
+	}
+}
+
+// pruneAttestation prunes attestations to keep attestations up to the last unbonding height
+// and the total number of attestations lower than the AttestationPruningThreshold.
+func pruneAttestation(ctx sdk.Context, k keeper.Keeper) {
+	oldestNonce := k.GetOldestAttestationNonce(ctx)
+	k.DeleteAttestation(ctx, oldestNonce)
+	ctx.Logger().Debug(
+		"pruned attestation from qgb store",
+		"nonce",
+		oldestNonce,
+	)
+
+	// persist the new last available attestation nonce
+	oldestNonce++
+	k.SetOldestAttestationNonce(ctx, uint64(oldestNonce))
+
+}
+
+var (
+	testPruningThreshold int64 = 0
+)
+
+// SetTestPruningThreshold sets the pruning threshold. NOTE: for testing
+// puruposes only. Calling this
+func SetTestPruningThreshold(threshold int64) {
+	testPruningThreshold = threshold
+}
+
+// PruningThreshold returns the PruningThreshold constant depending on app
+// version and context.
+//
+// NOTE: if the appversion is set to 0, and SetTestPruningThreshold, then that
+// value will be returned.
+func PruningThreshold(version uint64) int64 {
+	if testPruningThreshold != 0 && version == 0 {
+		return int64(testPruningThreshold)
+	}
+	return v1.PruningThreshold
+}

--- a/x/qgb/types/keys.go
+++ b/x/qgb/types/keys.go
@@ -28,6 +28,9 @@ const (
 	// LastUnBondingBlockHeight indexes the last validator unbonding block height
 	LastUnBondingBlockHeight = "LastUnBondingBlockHeight"
 
+	// LastValsetUpdateHeight indexes the last validator set udpate height
+	LastValsetUpdateHeight = "LastValsetUpdateHeight"
+
 	// LatestAttestationtNonce indexes the latest attestation request nonce
 	LatestAttestationtNonce = "LatestAttestationNonce"
 

--- a/x/qgb/types/keys.go
+++ b/x/qgb/types/keys.go
@@ -34,11 +34,8 @@ const (
 	// LatestAttestationtNonce indexes the latest attestation request nonce
 	LatestAttestationtNonce = "LatestAttestationNonce"
 
-	// LastAvailableAttestationNonce indexes the last available attestation nonce
-	LastAvailableAttestationNonce = "LastAvailableAttestationNonce"
-
-	// LastUnbondingNonce indexes the nonce corresponding to the last unbonding height
-	LastUnbondingNonce = "LastUnbondingNonce"
+	// OldestAttestationNonce indexes the last available attestation nonce
+	OldestAttestationNonce = "OldestAttestationNonce"
 )
 
 // GetAttestationKey returns the following key format

--- a/x/qgb/v1/consts.go
+++ b/x/qgb/v1/consts.go
@@ -1,0 +1,16 @@
+package v1
+
+const (
+	// PruningThreshold is the number of blocks we will wait to prune a given
+	// attestation. There is a single exception where we will not prune the last
+	// valset update if there has not been one since.
+	//
+	// Ideally, we should not prune before the unbonding period has ended.
+	// Roughly, assuming 15 second blocks, the unbonding period is 120960
+	// blocks. To be abundantly careful, a significantly larger value was
+	// chosen. In the worst case scenario, where state is pruned before the
+	// unbonding period and orchestrators have not been signing for 2+ weeks, we
+	// can manually query a snapshot or an archive node to get this state,
+	// however it is extremely unlikely to be needed.
+	PruningThreshold = 220000
+)


### PR DESCRIPTION
## Description

this PR attempts to simplify pruning by pruning attestations that are older than a threshold of blocks. It will stop pruning if there is only a single validator set update currently in the state, and will wait until there is another added before resuming.

I was too tired to write an integration test, but will tmrw
